### PR TITLE
Hide modal until calculating

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -42,10 +42,10 @@ function setupDOM() {
       calculer();
       btnApply.innerHTML = "Appliquer & Calculer";
       btnApply.disabled = false;
+      modal.style.display = 'none';
     }, 50); // Léger délai pour permettre au DOM de se rafraîchir
   };
   window.onclick = (event) => { if (event.target == modal) modal.style.display = 'none'; };
-  modal.style.display = 'flex';
 }
 
 function calculer() {

--- a/style.css
+++ b/style.css
@@ -114,3 +114,6 @@ main {
 }
 #toast.success { background-color: var(--success-color); }
 #toast.error { background-color: var(--danger-color); }
+
+/* Hide modal overlay by default */
+#modal { display: none; }


### PR DESCRIPTION
## Summary
- keep modal overlay hidden by default via CSS
- close modal after running calculations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68487e2a55088326aa6fdcb8fa6c3d64